### PR TITLE
Replace `Get-Module -ListAll` with a faster test

### DIFF
--- a/PowerShell Script to Save all Reports from Workspace.txt
+++ b/PowerShell Script to Save all Reports from Workspace.txt
@@ -21,22 +21,8 @@ foreach ($module in $requiredModules) {
        Install-Module -Name $module -Scope CurrentUser -Force
     }
 
-    Import-Module $Module -ErrorAction 'stop' # In the rare case Install-Module fails, you probably want a terminating error ( ex: -ErrorAction or a throw )
+    Import-Module $Module -ErrorAction 'stop' # In the rare case Install-Module fails, you probably want a terminating error
 }
-
-<#
-    "Get-Module -ListAvailable" is slow because it has extra work. If there's a lot of modules or cloud storage, it can take a long time.
-    We can use a faster option when the goal is: "is this module importable/installed" ?
-
-    Test for a truthy -PassThru:
-
-        Import-Module -PassThru -Ea Ignore
-
-    That always returns a non-empty result.
-    Both for the first import statement, and imports on already-loaded modules
-
-    Else empty when it isn't installed.
-#>
 
 # Login to Power BI
 Login-PowerBI

--- a/PowerShell Script to Save all Reports from Workspace.txt
+++ b/PowerShell Script to Save all Reports from Workspace.txt
@@ -14,16 +14,29 @@ if ($currentPolicy -eq 'Restricted' -or $currentPolicy -eq 'Undefined' -or $curr
     Write-Host "Current execution policy is sufficient: $currentPolicy."
 }
 
-# Check and install the necessary modules
-$requiredModules = @('MicrosoftPowerBIMgmt', 'ImportExcel')
+# Ensure required modules are installed, and imports them. If import fails, error and exit early
+$requiredModules = @( 'ImportExcel', 'MicrosoftPowerBIMgmt' )
 foreach ($module in $requiredModules) {
-    if (-not (Get-Module -ListAvailable -Name $module)) {
-        Install-Module -Name $module -Scope CurrentUser -Force
+    if( -not (Import-Module $module -PassThru -EA ignore) ) {
+       Install-Module -Name $module -Scope CurrentUser -Force
     }
+
+    Import-Module $Module -ErrorAction 'stop' # In the rare case Install-Module fails, you probably want a terminating error ( ex: -ErrorAction or a throw )
 }
 
-Import-Module ImportExcel
-Import-Module MicrosoftPowerBIMgmt
+<#
+    "Get-Module -ListAvailable" is slow because it has extra work. If there's a lot of modules or cloud storage, it can take a long time.
+    We can use a faster option when the goal is: "is this module importable/installed" ?
+
+    Test for a truthy -PassThru:
+
+        Import-Module -PassThru -Ea Ignore
+
+    That always returns a non-empty result.
+    Both for the first import statement, and imports on already-loaded modules
+
+    Else empty when it isn't installed.
+#>
 
 # Login to Power BI
 Login-PowerBI
@@ -57,4 +70,3 @@ foreach ($report in $reports) {
 }
 
 Write-Output "Reports exported to $new_date_folder"
- 


### PR DESCRIPTION
### About

`Get-Module -ListAvailable` becomes slow with more modules because it has to do extra work. 

It's not noticeable for a small number of files. A non-crazy amount can take `>1second`. 
Sometimes cloud storage includes the  default PSModulePaths ( for more overhead )

### Faster options

For cases when we just need to know "Is the module installed/importable?"

We can test for a truthy `Import-Module -PassThru`

```ps1
if( -not (Import-Module -PassThru -Ea Ignore ) ) { 
    'is not installed' 
}
```
- `PassThru` always returns a non-empty result on success
- Both for the first import statement, and future imports that are cached

In the rare case Install-Module fails, you probably want to end the script early. To prevent creating new directories and logging later errors. 

I used `Import-Module -ErrorAction Stop` to raise a terminating error.  Alternatively you could use `throw` or `return` 

### Benchmarks for `-ListAvailable` 

| Source | Using Import | Using ListAvailable |
| - | - | - |
| pwsh on a Windows dev machine | `~7.8ms` | `~780ms` |
| pwsh on the same machine, using `WSL` | `~2.5ms` | `~16ms` |

It's not a perfect test -- I used `wsl` as a quick comparison against an environment with few modules. 

### Script to test

```ps1
(Measure-Command { & {
  if( -not( Get-Module -ListAvailable -name 'importexcel' ) ) {
    'install it'
  }
} }).TotalMilliseconds

(Measure-Command { & {
  if( -not( Import-Module -name 'importexcel' -PassThru ) ) {
    'install it'
  }
} }).TotalMilliseconds

# inner & is used to prevent it from optimizing locals for a fairer test
```

